### PR TITLE
Pad minutes and seconds for H:MM:SS output

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "immutable": "^4.0.0-rc.1",
     "isomorphic-fetch": "^2.2.1",
     "jquery": "^3.1.1",
+    "left-pad": "^1.1.3",
     "node-schedule": "^1.2.3",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -8,6 +8,7 @@ import request from 'request'
 import dotenv from 'dotenv'
 import schedule from 'node-schedule'
 import { execSync } from 'child_process'
+import { leftPad } from 'left-pad'
 
 import { Server } from 'http'
 
@@ -294,8 +295,8 @@ function storeResults(fullResults, program) {
 }
 
 function secondsToTime(seconds) {
-  const s = seconds % 60
-  const m = Math.floor((seconds % 3600) / 60)
+  const s = leftPad(seconds % 60, 2, 0)
+  const m = leftPad(Math.floor((seconds % 3600) / 60), 2, 0)
   const h = Math.floor((seconds % 86400) / 3600)
   return `${h}:${m}:${s}`
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3457,6 +3457,10 @@ lcov-parse@0.0.10:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/lcov-parse/-/lcov-parse-0.0.10.tgz#1b0b8ff9ac9c7889250582b70b71315d9da6d9a3"
 
+left-pad@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/left-pad/-/left-pad-1.1.3.tgz#612f61c033f3a9e08e939f1caebeea41b6f3199a"
+
 leven@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/leven/-/leven-2.1.0.tgz#c2e7a9f772094dee9d34202ae8acce4687875580"


### PR DESCRIPTION
*Embarrassingly, I don't know how to actually test this, so I haven't. But it should work?*

`H:MM:SS` beats `H:M:S` because `0:04:01` beats `0:4:1`. Besides the aesthetic and usability improvement, `:0:` triggers a custom emoji in certain Slacks.